### PR TITLE
Sage button

### DIFF
--- a/static/js/qr.js
+++ b/static/js/qr.js
@@ -105,7 +105,7 @@ qr.setQr = function() {
   qrhtml += '</textarea></td></tr> ';
 
   qrhtml += '<tr><td colspan="2">';
-  qrhtml += '<input id="qrpassword" type="password" placeholder="Password"></td></tr>';
+  qrhtml += '<input id="qrpassword" type="password" placeholder="Password" autocomplete="off"></td></tr>';
 
   var noFlagDiv = document.getElementById('noFlagDiv');
 

--- a/templates/content/postingForm.html
+++ b/templates/content/postingForm.html
@@ -6,6 +6,7 @@
         type="text"
         class="postingInput"
         id="fieldName"
+        autocomplete="off"
         name="name"></td>
   </tr>
 
@@ -122,6 +123,7 @@
         type="text"
         class="postingInput"
         id="fieldEmail"
+        autocomplete="off"
         name="email"></td>
   </tr>
 
@@ -131,6 +133,7 @@
         id="fieldPostingPassword"
         name="password"
         class="postingInput"
+        autocomplete="off"
         type="password">
       <p class="small">(used to delete files and postings)</p></td>
   </tr>


### PR DESCRIPTION
Removes email field, replaces it with a sage check mark.
This is to avoid having new users put their real emails in their posts or accidentally submitting emails because of the user's browser auto-fill feature.
This PR also adds `autocomplete="off"` attributes to several elements, to mitigate the problem of passwords and names being auto-filled by the browser.